### PR TITLE
Add a "developer experience" label

### DIFF
--- a/config/dls-labels.json
+++ b/config/dls-labels.json
@@ -77,6 +77,7 @@
       "labels": [
         "cleanup",
         "dependencies",
+        "developer-experience",
         "documentation",
         "refactor",
         "accessibility",
@@ -100,7 +101,6 @@
       "color": "fffe99",
       "labels": [
         "dls-work-cycle",
-        "maintenance / research",
         "on deck",
         "operations"
       ]


### PR DESCRIPTION
also remove the label for the board we don't use anymore